### PR TITLE
Optimise sample Dockerfile to for better caching

### DIFF
--- a/Sample/Dockerfile
+++ b/Sample/Dockerfile
@@ -1,15 +1,21 @@
 FROM microsoft/dotnet:2.1-sdk as builder
 WORKDIR /usr/src/
+
+# Copy just the project file(s) and restore to take advantage of the docker multi-layer cache
+COPY SenseTest/*.csproj .
+RUN dotnet restore
+
+# Copy the remainder of the source files and build
 COPY SenseTest .
-RUN dotnet publish -r linux-arm -o /usr/src/dist
+RUN dotnet publish -o /usr/src/dist --no-restore
 
 FROM microsoft/dotnet:2.1-runtime
-WORKDIR /usr/app/
-COPY --from=builder /usr/src/dist .
 
 # https://github.com/dotnet/cli/issues/3390
 RUN apt-get update && \
     apt-get install libunwind8
 
-ENTRYPOINT [ "./SenseTest" ]
+WORKDIR /usr/app/
+COPY --from=builder /usr/src/dist .
 
+ENTRYPOINT [ "./SenseTest" ]

--- a/Sample/SenseTest/SenseTest.csproj
+++ b/Sample/SenseTest/SenseTest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SenseHatNet" Version="0.0.5" />


### PR DESCRIPTION
Hi. I'm no docker expert, but I've had a quick play around and made some little changes to make the docker build of the sample app quicker.

It's mostly just re-ordering stuff so that the stuff that doesn't usually change comes first (e.g. apt-get). That way docker's multi-layer cache is more likely to be able to re-use previous results.

I also split the build into separate restore & publish steps. This means that the results of the restore will be cached, as long as the csproj doesn't change. I moved the runtime identifier into the csproj, as I was getting a NETSDK1061 error without it.

Nice work on the .Net port, by the way. I've only just got my Pi & SenseHat, but I'm much happier in .Net (it's my day job). I'm probably going to look at routing this stuff through all the Azure IoT Edge stack.

Thanks.